### PR TITLE
fix(#7): Grade 엔티티의 performers 속성을 Session으로 이동 / 연관관계 지연 로딩 적용

### DIFF
--- a/src/main/java/com/bs/perform/dtos/request/GradeCreateDto.java
+++ b/src/main/java/com/bs/perform/dtos/request/GradeCreateDto.java
@@ -28,9 +28,6 @@ public class GradeCreateDto {
     @PositiveOrZero(message = "Price must be positive or zero")
     private BigDecimal price;
 
-    @NotBlank(message = "Performers must not be blank")
-    private String performers;
-
     @Positive(message = "Performance Id must be positive")
     @NotNull(message = "Performance type must not be null")
     private Long performanceId;
@@ -39,7 +36,6 @@ public class GradeCreateDto {
         return Grade.builder()
             .gradeType(this.gradeType)
             .price(this.price)
-            .performers(this.performers)
             .performance(performance)
             .build();
     }

--- a/src/main/java/com/bs/perform/dtos/request/GradeUpdateDto.java
+++ b/src/main/java/com/bs/perform/dtos/request/GradeUpdateDto.java
@@ -26,14 +26,11 @@ public class GradeUpdateDto {
     @PositiveOrZero(message = "Price must be positive or zero")
     private BigDecimal price;
 
-    @NotBlank(message = "Performers must not be blank")
-    private String performers;
 
     public Grade toEntity() {
         return Grade.builder()
             .gradeType(this.gradeType)
             .price(this.price)
-            .performers(this.performers)
             .build();
     }
 }

--- a/src/main/java/com/bs/perform/dtos/request/SessionCreateDto.java
+++ b/src/main/java/com/bs/perform/dtos/request/SessionCreateDto.java
@@ -2,6 +2,7 @@ package com.bs.perform.dtos.request;
 
 import com.bs.perform.models.Performance;
 import com.bs.perform.models.Session;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -27,6 +28,9 @@ public class SessionCreateDto {
     @NotNull(message = "Session time must not be null")
     private LocalTime sessionTime;
 
+    @NotBlank(message = "Performers must not be blank")
+    private String performers;
+
     @Positive(message = "Performance Id must be positive")
     @NotNull(message = "Performance Id must not be null")
     private Long performanceId;
@@ -35,6 +39,7 @@ public class SessionCreateDto {
         return Session.builder()
             .sessionDate(this.sessionDate)
             .sessionTime(this.sessionTime)
+            .performers(this.performers)
             .performance(performance)
             .build();
     }

--- a/src/main/java/com/bs/perform/dtos/request/SessionUpdateDto.java
+++ b/src/main/java/com/bs/perform/dtos/request/SessionUpdateDto.java
@@ -2,6 +2,7 @@ package com.bs.perform.dtos.request;
 
 import com.bs.perform.models.Performance;
 import com.bs.perform.models.Session;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -25,10 +26,14 @@ public class SessionUpdateDto {
     @NotNull(message = "Session time must not be null")
     private LocalTime sessionTime;
 
+    @NotBlank(message = "Performers must not be blank")
+    private String performers;
+
     public Session toEntity(Performance performance) {
         return Session.builder()
             .sessionDate(this.sessionDate)
             .sessionTime(this.sessionTime)
+            .performers(this.performers)
             .build();
     }
 }

--- a/src/main/java/com/bs/perform/dtos/response/GradeGetResponseDto.java
+++ b/src/main/java/com/bs/perform/dtos/response/GradeGetResponseDto.java
@@ -19,7 +19,6 @@ public class GradeGetResponseDto {
 
     private GradeType gradeType;
     private BigDecimal price;
-    private String performers;
     private Long performanceId;
 
 }

--- a/src/main/java/com/bs/perform/dtos/response/SessionGetResponseDto.java
+++ b/src/main/java/com/bs/perform/dtos/response/SessionGetResponseDto.java
@@ -17,6 +17,7 @@ public class SessionGetResponseDto {
 
     private LocalDate sessionDate;
     private LocalTime sessionTime;
+    private String performers;
     private Long performanceId;
 
 }

--- a/src/main/java/com/bs/perform/models/Grade.java
+++ b/src/main/java/com/bs/perform/models/Grade.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,26 +35,21 @@ public class Grade extends BaseEntity {
     @Column(nullable = false)
     private BigDecimal price;
 
-    @Column(nullable = false)
-    private String performers;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id")
     private Performance performance;
 
     @Builder
-    public Grade(GradeType gradeType, BigDecimal price, String performers,
+    public Grade(GradeType gradeType, BigDecimal price,
         Performance performance) {
         this.gradeType = Objects.requireNonNull(gradeType, "grade must not be null");
         this.price = Objects.requireNonNull(price, "price must not be null");
-        this.performers = Objects.requireNonNull(performers, "performers must not be null");
         this.performance = Objects.requireNonNull(performance, "performance must not be null");
     }
 
-    public void updateGrade(GradeType gradeType, BigDecimal price, String performers) {
+    public void updateGrade(GradeType gradeType, BigDecimal price) {
         this.gradeType = Objects.requireNonNull(gradeType, "grade must not be null");
         this.price = Objects.requireNonNull(price, "price must not be null");
-        this.performers = Objects.requireNonNull(performers, "performers must not be null");
     }
 
     public void deleteGrade() {

--- a/src/main/java/com/bs/perform/models/Performance.java
+++ b/src/main/java/com/bs/perform/models/Performance.java
@@ -2,6 +2,7 @@ package com.bs.perform.models;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -46,7 +47,7 @@ public class Performance extends BaseEntity {
     @Column(nullable = false)
     private LocalDate reservationEndDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "venue_id")
     private Venue venue;
 

--- a/src/main/java/com/bs/perform/models/Seat.java
+++ b/src/main/java/com/bs/perform/models/Seat.java
@@ -2,6 +2,7 @@ package com.bs.perform.models;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,7 +30,7 @@ public class Seat extends BaseEntity {
     @Column(nullable = false)
     private int col;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "venue_id", nullable = false)
     private Venue venue;
 

--- a/src/main/java/com/bs/perform/models/SeatGrade.java
+++ b/src/main/java/com/bs/perform/models/SeatGrade.java
@@ -2,6 +2,7 @@ package com.bs.perform.models;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,11 +24,11 @@ public class SeatGrade extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seat_id")
     private Seat seat;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "grade_id")
     private Grade grade;
 

--- a/src/main/java/com/bs/perform/models/Session.java
+++ b/src/main/java/com/bs/perform/models/Session.java
@@ -2,6 +2,7 @@ package com.bs.perform.models;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,20 +32,25 @@ public class Session extends BaseEntity {
     @Column(nullable=false)
     private LocalTime sessionTime;
 
-    @ManyToOne
+    @Column(nullable = false)
+    private String performers;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id")
     private Performance performance;
 
     @Builder
-    public Session(LocalDate sessionDate, LocalTime sessionTime, Performance performance) {
+    public Session(LocalDate sessionDate, LocalTime sessionTime, String performers, Performance performance) {
         this.sessionDate = Objects.requireNonNull(sessionDate, "sessionDate must not be null");
         this.sessionTime = Objects.requireNonNull(sessionTime, "sessionTime must not be null");
+        this.performers = Objects.requireNonNull(performers, "performers must not be null");
         this.performance = Objects.requireNonNull(performance, "performance must not be null");
     }
 
-    public void updateSession(LocalDate sessionDate, LocalTime sessionTime) {
+    public void updateSession(LocalDate sessionDate, LocalTime sessionTime, String performers) {
         this.sessionDate = Objects.requireNonNull(sessionDate, "sessionDate must not be null");
         this.sessionTime = Objects.requireNonNull(sessionTime, "sessionTime must not be null");
+        this.performers = Objects.requireNonNull(performers, "performers must not be null");
     }
 
     public void deleteSession() {

--- a/src/main/java/com/bs/perform/services/GradeServiceImpl.java
+++ b/src/main/java/com/bs/perform/services/GradeServiceImpl.java
@@ -44,7 +44,7 @@ public class GradeServiceImpl implements GradeService {
 
         Grade grade = getGrade(id);
 
-        grade.updateGrade(gradeDto.getGradeType(), gradeDto.getPrice(), gradeDto.getPerformers());
+        grade.updateGrade(gradeDto.getGradeType(), gradeDto.getPrice());
 
     }
 

--- a/src/main/java/com/bs/perform/services/SessionServiceImpl.java
+++ b/src/main/java/com/bs/perform/services/SessionServiceImpl.java
@@ -43,7 +43,7 @@ public class SessionServiceImpl implements SessionService {
         log.info("Updating session with SessionUpdateDto: {}", sessionDto);
         Session session = getSession(id);
 
-        session.updateSession(sessionDto.getSessionDate(), sessionDto.getSessionTime());
+        session.updateSession(sessionDto.getSessionDate(), sessionDto.getSessionTime(), sessionDto.getPerformers());
     }
 
     @Override

--- a/src/test/java/com/bs/perform/controllers/GradeControllerTest.java
+++ b/src/test/java/com/bs/perform/controllers/GradeControllerTest.java
@@ -62,7 +62,6 @@ class GradeControllerTest {
         GradeCreateDto dto = GradeCreateDto.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performanceId(performanceId)
             .build();
 
@@ -95,7 +94,6 @@ class GradeControllerTest {
         GradeUpdateDto UpdateDto = GradeUpdateDto.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .build();
 
         doNothing().when(gradeService).updateGrade(gradeId, UpdateDto);
@@ -127,7 +125,6 @@ class GradeControllerTest {
         GradeGetResponseDto responseDto = GradeGetResponseDto.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performanceId(performanceId)
             .build();
 
@@ -136,8 +133,7 @@ class GradeControllerTest {
         mockMvc.perform(get("/grades/" + gradeId)
                 .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.price").value(responseDto.getPrice()))
-            .andExpect(jsonPath("$.performers").value(responseDto.getPerformers()));
+            .andExpect(jsonPath("$.price").value(responseDto.getPrice()));
     }
 
     @Test
@@ -176,7 +172,6 @@ class GradeControllerTest {
         return Grade.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }

--- a/src/test/java/com/bs/perform/controllers/SeatGradeControllerTest.java
+++ b/src/test/java/com/bs/perform/controllers/SeatGradeControllerTest.java
@@ -152,7 +152,6 @@ class SeatGradeControllerTest {
         return Grade.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }

--- a/src/test/java/com/bs/perform/controllers/SessionControllerTest.java
+++ b/src/test/java/com/bs/perform/controllers/SessionControllerTest.java
@@ -67,6 +67,7 @@ class SessionControllerTest {
             SessionCreateDto createDto = SessionCreateDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20, 00, 00))
+                .performers("배우1, 배우2, 배우3")
                 .performanceId(performanceId)
                 .build();
 
@@ -104,6 +105,7 @@ class SessionControllerTest {
             SessionUpdateDto updateDto = SessionUpdateDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20, 00, 00))
+                .performers("배우1, 배우2, 배우3")
                 .build();
 
             doNothing().when(sessionService).updateSession(sessionId, updateDto);
@@ -140,6 +142,7 @@ class SessionControllerTest {
             SessionGetResponseDto responseDto = SessionGetResponseDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20, 00, 00))
+                .performers("배우1, 배우2, 배우3")
                 .performanceId(performanceId)
                 .build();
 
@@ -186,6 +189,7 @@ class SessionControllerTest {
         return Session.builder()
             .sessionDate(LocalDate.of(2023, 7, 15))
             .sessionTime(LocalTime.of(20, 00, 00))
+            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }

--- a/src/test/java/com/bs/perform/services/GradeServiceTest.java
+++ b/src/test/java/com/bs/perform/services/GradeServiceTest.java
@@ -69,7 +69,6 @@ class GradeServiceTest {
             GradeCreateDto createDto = GradeCreateDto.builder()
                 .gradeType(GradeType.VIP)
                 .price(new BigDecimal(200000))
-                .performers("배우1, 배우2, 배우3")
                 .performanceId(performanceId)
                 .build();
 
@@ -101,7 +100,6 @@ class GradeServiceTest {
 
             GradeCreateDto createDto = GradeCreateDto.builder()
                 .price(new BigDecimal(200000))
-                .performers("배우1, 배우2, 배우3")
                 .build();
 
             assertThatThrownBy(() -> gradeService.createGrade(createDto))
@@ -121,7 +119,6 @@ class GradeServiceTest {
             GradeUpdateDto updateDto = GradeUpdateDto.builder()
                 .gradeType(GradeType.VIP)
                 .price(new BigDecimal(200000))
-                .performers("배우1, 배우2, 배우3")
                 .build();
 
             doReturn(Optional.of(grade)).when(gradeRepository).findByIdAndIsDeletedFalse(gradeId);
@@ -156,7 +153,6 @@ class GradeServiceTest {
             GradeGetResponseDto responseDto = GradeGetResponseDto.builder()
                 .gradeType(GradeType.VIP)
                 .price(new BigDecimal(200000))
-                .performers("배우1, 배우2, 배우3")
                 .performanceId(performanceId)
                 .build();
 
@@ -202,7 +198,6 @@ class GradeServiceTest {
         return Grade.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }

--- a/src/test/java/com/bs/perform/services/SeatGradeServiceTest.java
+++ b/src/test/java/com/bs/perform/services/SeatGradeServiceTest.java
@@ -162,7 +162,6 @@ class SeatGradeServiceTest {
         return Grade.builder()
             .gradeType(GradeType.VIP)
             .price(new BigDecimal(200000))
-            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }

--- a/src/test/java/com/bs/perform/services/SessionServiceTest.java
+++ b/src/test/java/com/bs/perform/services/SessionServiceTest.java
@@ -83,6 +83,7 @@ class SessionServiceTest {
             SessionCreateDto createDto = SessionCreateDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20,00,00))
+                .performers("배우1, 배우2, 배우3")
                 .performanceId(performanceId)
                 .build();
 
@@ -122,6 +123,7 @@ class SessionServiceTest {
             SessionUpdateDto updateDto = SessionUpdateDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20,00,00))
+                .performers("배우1, 배우2, 배우3")
                 .build();
 
             doReturn(Optional.of(session)).when(sessionRepository).findByIdAndIsDeletedFalse(sessionId);
@@ -157,6 +159,7 @@ class SessionServiceTest {
             SessionGetResponseDto responseDto = SessionGetResponseDto.builder()
                 .sessionDate(LocalDate.of(2023, 7, 15))
                 .sessionTime(LocalTime.of(20,00,00))
+                .performers("배우1, 배우2, 배우3")
                 .build();
 
             doReturn(Optional.of(session)).when(sessionRepository).findByIdAndIsDeletedFalse(sessionId);
@@ -202,6 +205,7 @@ class SessionServiceTest {
         return Session.builder()
             .sessionDate(LocalDate.of(2023, 7, 15))
             .sessionTime(LocalTime.of(20,00,00))
+            .performers("배우1, 배우2, 배우3")
             .performance(performance)
             .build();
     }


### PR DESCRIPTION
- [x] Grade 엔티티의 performers(출연진) 속성을 Session으로 이동
- [x] 연관관계 지연 로딩 적용
- [x] Docker 배포 테스트
