### PR TITLE
refactor(#17): 예매 서비스로 공연 회차 좌석 목록 전송 시 호출 API 경로 변경

### DIFF
--- a/src/main/java/com/bs/perform/apis/ReservationRestClient.java
+++ b/src/main/java/com/bs/perform/apis/ReservationRestClient.java
@@ -28,14 +28,12 @@ public class ReservationRestClient {
         log.info("sendSessionSeatGradeToReservation with ID: {}, SessionSeatRequestDto: {}", performanceId, requestDto);
 
         String url = externalServiceReservationUrl + "/seats/batch";
-
         ResponseEntity<CommonResponseDto> response = restTemplate.postForEntity(url, requestDto, CommonResponseDto.class);
         validateResponse(response);
-
     }
 
     private static void validateResponse(ResponseEntity<CommonResponseDto> response) {
-        if(response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+        if(!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
             throw new ExternalServiceException("Sessions seats not created. HTTP Status: " + response.getStatusCode());
         }
     }

--- a/src/main/java/com/bs/perform/apis/ReservationRestClient.java
+++ b/src/main/java/com/bs/perform/apis/ReservationRestClient.java
@@ -1,10 +1,16 @@
 package com.bs.perform.apis;
 
+import com.bs.perform.dtos.response.CommonResponseDto;
 import com.bs.perform.dtos.response.SessionSeatRequestDto;
+import com.bs.perform.exceptions.ExternalServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -17,12 +23,21 @@ public class ReservationRestClient {
     @Value("${external.service.reservation.url}")
     private String externalServiceReservationUrl;
 
-    public SessionSeatRequestDto sendSessionSeatGradeToReservation(final Long performanceId, final SessionSeatRequestDto requestDto) {
+    public void sendSessionSeatGradeToReservation(final Long performanceId, final SessionSeatRequestDto requestDto) {
 
         log.info("sendSessionSeatGradeToReservation with ID: {}, SessionSeatRequestDto: {}", performanceId, requestDto);
 
-        String url = externalServiceReservationUrl + "/seats/" + performanceId;
-        return restTemplate.postForObject(url, requestDto, SessionSeatRequestDto.class);
+        String url = externalServiceReservationUrl + "/seats/batch";
+
+        ResponseEntity<CommonResponseDto> response = restTemplate.postForEntity(url, requestDto, CommonResponseDto.class);
+        validateResponse(response);
+
+    }
+
+    private static void validateResponse(ResponseEntity<CommonResponseDto> response) {
+        if(response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new ExternalServiceException("Sessions seats not created. HTTP Status: " + response.getStatusCode());
+        }
     }
 
 }

--- a/src/main/java/com/bs/perform/controllers/SessionSeatController.java
+++ b/src/main/java/com/bs/perform/controllers/SessionSeatController.java
@@ -2,18 +2,12 @@ package com.bs.perform.controllers;
 
 import com.bs.perform.dtos.response.CommonResponseDto;
 import com.bs.perform.dtos.response.SessionSeatDto;
-import com.bs.perform.dtos.response.SessionSeatRequestDto;
 import com.bs.perform.services.interfaces.SessionSeatGradeService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestClientException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,12 +27,7 @@ public class SessionSeatController {
     @ResponseStatus(HttpStatus.OK)
     public CommonResponseDto sendSessionSeatGradeToReservation(@PathVariable final Long id) {
 
-        SessionSeatRequestDto sessionSeatRequestDto = sessionSeatGradeService.sendSessionSeatGradeToReservation(
-            id);
-
-        if (!sessionSeatRequestDto.getStatus().equals("success")) {
-            throw new RestClientException("Sessions seats not created");
-        }
+        sessionSeatGradeService.sendSessionSeatGradeToReservation(id);
 
         return new CommonResponseDto(HttpStatus.OK.toString(), "successfully sent");
     }

--- a/src/main/java/com/bs/perform/dtos/response/SessionSeatDto.java
+++ b/src/main/java/com/bs/perform/dtos/response/SessionSeatDto.java
@@ -1,12 +1,9 @@
 package com.bs.perform.dtos.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 
+@ToString
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/bs/perform/dtos/response/SessionSeatRequestDto.java
+++ b/src/main/java/com/bs/perform/dtos/response/SessionSeatRequestDto.java
@@ -1,13 +1,11 @@
 package com.bs.perform.dtos.response;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import lombok.*;
 
 
+@ToString
 @Getter
 @Setter
 @Builder

--- a/src/main/java/com/bs/perform/exceptions/ControllerAdvice.java
+++ b/src/main/java/com/bs/perform/exceptions/ControllerAdvice.java
@@ -42,10 +42,16 @@ public class ControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(ExternalServiceException.class)
+    public ErrorResultResponseDto externalServiceExceptionHandler(ExternalServiceException e) {
+        log.error("[ExternalServiceException] ex", e);
+        return new ErrorResultResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler
     public ErrorResultResponseDto exHandler(Exception e) {
         log.error("[exceptionHandler] ex", e);
-        return new ErrorResultResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.toString(),
-            e.getMessage());
+        return new ErrorResultResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
     }
 }

--- a/src/main/java/com/bs/perform/exceptions/ExternalServiceException.java
+++ b/src/main/java/com/bs/perform/exceptions/ExternalServiceException.java
@@ -1,0 +1,10 @@
+package com.bs.perform.exceptions;
+
+import org.springframework.web.client.ResourceAccessException;
+
+public class ExternalServiceException extends RuntimeException {
+
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bs/perform/services/SessionSeatGradeServiceImpl.java
+++ b/src/main/java/com/bs/perform/services/SessionSeatGradeServiceImpl.java
@@ -11,12 +11,13 @@ import com.bs.perform.repositories.PerformanceRepository;
 import com.bs.perform.repositories.SeatGradeRepository;
 import com.bs.perform.repositories.SessionRepository;
 import com.bs.perform.services.interfaces.SessionSeatGradeService;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,15 +39,15 @@ public class SessionSeatGradeServiceImpl implements SessionSeatGradeService {
     }
 
     @Override
-    public SessionSeatRequestDto sendSessionSeatGradeToReservation(final Long performanceId) {
+    public void sendSessionSeatGradeToReservation(final Long performanceId) {
 
         log.info("sendSessionSeatGradeToReservation with ID: {}", performanceId);
 
         SessionSeatRequestDto sessionSeatRequestDto = SessionSeatRequestDto.builder()
-            .data(getSessionSeats(performanceId))
-            .build();
+                .data(getSessionSeats(performanceId))
+                .build();
 
-        return reservationRestClientService.sendSessionSeatGradeToReservation(performanceId, sessionSeatRequestDto);
+        reservationRestClientService.sendSessionSeatGradeToReservation(performanceId, sessionSeatRequestDto);
     }
 
     private List<SessionSeatDto> getSessionSeats(Long performanceId) {
@@ -56,31 +57,31 @@ public class SessionSeatGradeServiceImpl implements SessionSeatGradeService {
         List<SeatGrade> seatGrades = findSeatGrades(performance);
 
         return sessions.stream()
-            .flatMap(session -> seatGrades.stream()
-                .map(seatGrade -> SessionSeatDto.builder()
-                    .performanceId(performanceId)
-                    .sessionId(session.getId())
-                    .seatGradeId(seatGrade.getId())
-                    .build()))
-            .collect(Collectors.toList());
+                .flatMap(session -> seatGrades.stream()
+                        .map(seatGrade -> SessionSeatDto.builder()
+                                .performanceId(performanceId)
+                                .sessionId(session.getId())
+                                .seatGradeId(seatGrade.getId())
+                                .build()))
+                .collect(Collectors.toList());
     }
 
     private Performance getPerformance(Long performanceId) {
         return performanceRepository.findByIdAndIsDeletedFalse(performanceId)
-            .orElseThrow(
-                () -> new ResourceNotFoundException("Performance", String.valueOf(performanceId)));
+                .orElseThrow(
+                        () -> new ResourceNotFoundException("Performance", String.valueOf(performanceId)));
     }
 
     private List<Session> findSessions(Long performanceId) {
         List<Session> sessions = sessionRepository.findByPerformanceIdAndIsDeletedFalse(
-            performanceId);
+                performanceId);
 
         log.info("Fetched {} sessions objects for performanceId: {}", sessions.size(),
-            performanceId);
+                performanceId);
 
         if (sessions.isEmpty()) {
             throw new ResourceNotFoundException("sessions of performance",
-                String.valueOf(performanceId));
+                    String.valueOf(performanceId));
         }
         return sessions;
     }
@@ -89,11 +90,11 @@ public class SessionSeatGradeServiceImpl implements SessionSeatGradeService {
         List<SeatGrade> seatGrades = seatGradeRepository.findGradeFetchJoinSeatGrade(performance);
 
         log.info("Fetched {} seatGrades objects for performanceId: {}", seatGrades.size(),
-            performance.getId());
+                performance.getId());
 
         if (seatGrades.isEmpty()) {
             throw new ResourceNotFoundException("seatGrades of performance",
-                String.valueOf(performance.getId()));
+                    String.valueOf(performance.getId()));
         }
         return seatGrades;
     }

--- a/src/main/java/com/bs/perform/services/interfaces/SessionSeatGradeService.java
+++ b/src/main/java/com/bs/perform/services/interfaces/SessionSeatGradeService.java
@@ -1,12 +1,12 @@
 package com.bs.perform.services.interfaces;
 
 import com.bs.perform.dtos.response.SessionSeatDto;
-import com.bs.perform.dtos.response.SessionSeatRequestDto;
+
 import java.util.List;
 
 public interface SessionSeatGradeService {
 
     List<SessionSeatDto> getSessionSeatGradeById(final Long performanceId);
 
-    SessionSeatRequestDto sendSessionSeatGradeToReservation(final Long performanceId);
+    void sendSessionSeatGradeToReservation(final Long performanceId);
 }

--- a/src/test/java/com/bs/perform/controllers/SessionSeatControllerTest.java
+++ b/src/test/java/com/bs/perform/controllers/SessionSeatControllerTest.java
@@ -1,21 +1,9 @@
 package com.bs.perform.controllers;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import com.bs.perform.dtos.response.CommonResponseDto;
 import com.bs.perform.dtos.response.SessionSeatDto;
-import com.bs.perform.dtos.response.SessionSeatRequestDto;
 import com.bs.perform.exceptions.ResourceNotFoundException;
 import com.bs.perform.services.interfaces.SessionSeatGradeService;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +14,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.RestClientException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -53,12 +51,12 @@ class SessionSeatControllerTest {
 
         List<SessionSeatDto> expectedResponse = Arrays.asList(sessionSeatDto);
         doReturn(expectedResponse).when(sessionSeatGradeService).getSessionSeatGradeById(
-            performanceId);
+                performanceId);
 
         mockMvc.perform(get("/performances/" + performanceId + "/sessionSeats")
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$", hasSize(1)));
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)));
 
         verify(sessionSeatGradeService, times(1)).getSessionSeatGradeById(performanceId);
     }
@@ -68,12 +66,12 @@ class SessionSeatControllerTest {
     void getSessionSeatGradeFailureTest() throws Exception {
 
         doThrow(ResourceNotFoundException.class).when(sessionSeatGradeService)
-            .getSessionSeatGradeById(
-                performanceId);
+                .getSessionSeatGradeById(
+                        performanceId);
 
         mockMvc.perform(get("/performances/" + performanceId + "/sessionSeats")
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
 
         verify(sessionSeatGradeService, times(1)).getSessionSeatGradeById(performanceId);
     }
@@ -83,15 +81,14 @@ class SessionSeatControllerTest {
     void sendSessionSeatGradeSuccessTest() throws Exception {
 
         List<SessionSeatDto> sessionSeatDtos = Arrays.asList(this.sessionSeatDto);
-        SessionSeatRequestDto sessionSeatRequestDto = new SessionSeatRequestDto(sessionSeatDtos,
-            "success", "");
+        CommonResponseDto commonResponseDto = new CommonResponseDto("success", "");
 
-        doReturn(sessionSeatRequestDto).when(sessionSeatGradeService)
-            .sendSessionSeatGradeToReservation(performanceId);
+        doNothing().when(sessionSeatGradeService)
+                .sendSessionSeatGradeToReservation(performanceId);
 
         mockMvc.perform(post("/performances/" + performanceId + "/sessionSeats")
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -99,10 +96,10 @@ class SessionSeatControllerTest {
     void sendSessionSeatGradeFailureTest() throws Exception {
 
         doThrow(RestClientException.class).when(sessionSeatGradeService)
-            .sendSessionSeatGradeToReservation(performanceId);
+                .sendSessionSeatGradeToReservation(performanceId);
 
         mockMvc.perform(post("/performances/" + performanceId + "/sessionSeats")
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isInternalServerError());
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError());
     }
 }

--- a/src/test/java/com/bs/perform/services/SessionSeatGradeServiceImplTest.java
+++ b/src/test/java/com/bs/perform/services/SessionSeatGradeServiceImplTest.java
@@ -1,15 +1,5 @@
 package com.bs.perform.services;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.bs.perform.apis.ReservationRestClient;
 import com.bs.perform.dtos.response.SessionSeatDto;
 import com.bs.perform.dtos.response.SessionSeatRequestDto;
@@ -20,10 +10,6 @@ import com.bs.perform.models.Session;
 import com.bs.perform.repositories.PerformanceRepository;
 import com.bs.perform.repositories.SeatGradeRepository;
 import com.bs.perform.repositories.SessionRepository;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClientException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class SessionSeatGradeServiceImplTest {
@@ -70,14 +65,14 @@ public class SessionSeatGradeServiceImplTest {
     void getSessionSeatGradeByIdSuccessTest() {
 
         doReturn(Optional.of(performance)).when(performanceRepository)
-            .findByIdAndIsDeletedFalse(anyLong());
+                .findByIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(session)).when(sessionRepository)
-            .findByPerformanceIdAndIsDeletedFalse(anyLong());
+                .findByPerformanceIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(seatGrade)).when(seatGradeRepository)
-            .findGradeFetchJoinSeatGrade(any());
+                .findGradeFetchJoinSeatGrade(any());
 
         List<SessionSeatDto> result = sessionSeatGradeService.getSessionSeatGradeById(
-            performanceId);
+                performanceId);
 
         verify(performanceRepository, times(1)).findByIdAndIsDeletedFalse(anyLong());
         verify(sessionRepository, times(1)).findByPerformanceIdAndIsDeletedFalse(anyLong());
@@ -91,36 +86,32 @@ public class SessionSeatGradeServiceImplTest {
         doReturn(Optional.empty()).when(performanceRepository).findByIdAndIsDeletedFalse(anyLong());
 
         assertThatThrownBy(() -> sessionSeatGradeService.getSessionSeatGradeById(performanceId))
-            .isInstanceOf(ResourceNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class);
 
         verify(performanceRepository, times(1)).findByIdAndIsDeletedFalse(anyLong());
     }
 
     @Test
-    @DisplayName("유효한 performanceId가 주어졌을 때, SessionSeatResponseDto를 반환")
+    @DisplayName("유효한 performanceId가 주어졌을 때, 정상적으로 처리")
     void sendSessionSeatGradeToReservationSuccessTest() {
 
-        SessionSeatDto sessionSeatDto = SessionSeatDto.builder().performanceId(1L).sessionId(1L)
-            .seatGradeId(1L).build();
+        SessionSeatDto sessionSeatDto = SessionSeatDto.builder().sessionId(1L)
+                .seatGradeId(1L).build();
         List<SessionSeatDto> sessionSeatDtos = Arrays.asList(sessionSeatDto);
-        SessionSeatRequestDto sessionSeatRequestDto = new SessionSeatRequestDto(sessionSeatDtos,
-            "success", "");
 
         doReturn(Optional.of(performance)).when(performanceRepository)
-            .findByIdAndIsDeletedFalse(anyLong());
+                .findByIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(session)).when(sessionRepository)
-            .findByPerformanceIdAndIsDeletedFalse(anyLong());
+                .findByPerformanceIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(seatGrade)).when(seatGradeRepository)
-            .findGradeFetchJoinSeatGrade(any());
-        doReturn(sessionSeatRequestDto).when(reservationRestClient)
-            .sendSessionSeatGradeToReservation(anyLong(), any(SessionSeatRequestDto.class));
+                .findGradeFetchJoinSeatGrade(any());
+        doNothing().when(reservationRestClient)
+                .sendSessionSeatGradeToReservation(anyLong(), any(SessionSeatRequestDto.class));
 
-        SessionSeatRequestDto result = sessionSeatGradeService.sendSessionSeatGradeToReservation(
-            performanceId);
+        sessionSeatGradeService.sendSessionSeatGradeToReservation(performanceId);
 
-        assertThat(result).isEqualTo(sessionSeatRequestDto);
         verify(reservationRestClient, times(1)).sendSessionSeatGradeToReservation(anyLong(),
-            any(SessionSeatRequestDto.class));
+                any(SessionSeatRequestDto.class));
     }
 
     @Test
@@ -129,17 +120,17 @@ public class SessionSeatGradeServiceImplTest {
 
 
         doReturn(Optional.of(performance)).when(performanceRepository)
-            .findByIdAndIsDeletedFalse(anyLong());
+                .findByIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(session)).when(sessionRepository)
-            .findByPerformanceIdAndIsDeletedFalse(anyLong());
+                .findByPerformanceIdAndIsDeletedFalse(anyLong());
         doReturn(Collections.singletonList(seatGrade)).when(seatGradeRepository)
-            .findGradeFetchJoinSeatGrade(any());
+                .findGradeFetchJoinSeatGrade(any());
         doThrow(RestClientException.class).when(reservationRestClient)
-            .sendSessionSeatGradeToReservation(anyLong(), any(SessionSeatRequestDto.class));
+                .sendSessionSeatGradeToReservation(anyLong(), any(SessionSeatRequestDto.class));
 
         assertThatThrownBy(
-            () -> sessionSeatGradeService.sendSessionSeatGradeToReservation(performanceId))
-            .isInstanceOf(RestClientException.class);
+                () -> sessionSeatGradeService.sendSessionSeatGradeToReservation(performanceId))
+                .isInstanceOf(RestClientException.class);
     }
 
 }


### PR DESCRIPTION
- 예매 서비스로 공연 회차 좌석 목록 전송 시 호출 API 경로 변경 
- 예매 서비스 응답 DTO 변경 및 응답 값 검증 로직 구현